### PR TITLE
Update UpdateHandler.php

### DIFF
--- a/src/danog/MadelineProto/MTProtoTools/UpdateHandler.php
+++ b/src/danog/MadelineProto/MTProtoTools/UpdateHandler.php
@@ -334,7 +334,7 @@ trait UpdateHandler
                     if (!isset($this->calls[$update['phone_call']['id']])) {
                         return;
                     }
-                    return $this->calls[$update['phone_call']['id']]->discard($update['phone_call']['reason'] ?? [], [], $update['phone_call']['need_debug'] ?? false);
+                    return $this->calls[$update['phone_call']['id']]->discard($update['phone_call']['reason'] ?? ['_' => 'phoneCallDiscardReasonDisconnect'], [], $update['phone_call']['need_debug'] ?? false);
             }
         }
         if ($update['_'] === 'updateNewEncryptedMessage' && !isset($update['message']['decrypted_message'])) {


### PR DESCRIPTION
Instead passing empty array as reason pass `['_' => 'phoneCallDiscardReasonDisconnect']` in case the reason is not present

By according documentation the reason is optional:
https://core.telegram.org/constructor/phoneCallDiscarded